### PR TITLE
Add typescript module declaration for localdata.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'localdata' {
+    import ldb from 'localstoragedb'
+
+    class ldbInterface {
+        static get(key: string, callback: (string) => void): void {
+            ldb.get(key, callback);
+        }
+        static set(key: string, val: string, callback?: () => void): void {
+            ldb.set(key, val, callback);
+        }
+        static delete(key: string, callback?: () => void): void {
+            ldb.delete(key, callback);
+        }
+        static list(callback: (result: string[]) => void): void {
+            ldb.list(callback);
+        }
+        static getAll(callback: (result: string[]) => void): void {
+            ldb.getAll(callback);
+        }
+        static clear(callback?: () => void): void {
+            ldb.clear(callback);
+        }
+    }
+
+    export default ldbInterface;
+}


### PR DESCRIPTION
 In my local testing, this seems to make the import command via npm install work for me (in a Typescript project). Open to any suggestions/preferences, this is just what was working for me locally. 